### PR TITLE
Use correct gcodes in PRINT_END

### DIFF
--- a/configs/x-smart-3/control.cfg
+++ b/configs/x-smart-3/control.cfg
@@ -6,8 +6,8 @@ Description: After print clean up
 gcode:
     # lower bed & park toolhead
     G90
-    G0 Z175
-    G0 X5 Y170 F12000
+    G0 Z{printer.toolhead.axis_maximum.z} F1000
+    G0 X{printer.toolhead.axis_minimum.x + 5} Y{printer.toolhead.axis_maximum.y - 5} F5000
 
     # clear pause state in case of cancel after pause
     CLEAR_PAUSE

--- a/configs/x-smart-3/control.cfg
+++ b/configs/x-smart-3/control.cfg
@@ -5,9 +5,10 @@ gcode:
 Description: After print clean up
 gcode:
     # lower bed & park toolhead
+    {% set z_end = printer.configfile.settings.stepper_z.position_max - 1 %}
     G90
-    G0 Z{printer.toolhead.axis_maximum.z} F1000
-    G0 X{printer.toolhead.axis_minimum.x + 5} Y{printer.toolhead.axis_maximum.y - 5} F5000
+    G0 Z{z_end} F5000
+    G0 X5 Y180 F10000
 
     # clear pause state in case of cancel after pause
     CLEAR_PAUSE
@@ -38,9 +39,9 @@ gcode:
 
     # annoy user into removing print
     {% set beep_state = printer["output_pin sound"].value | int %}
-        BEEP_ON
-        BEEP I=2 DUR=1000
-    {% printer["output_pin sound"].value = beep_state %}
+    BEEP_ON
+    BEEP I=3 DUR=1000
+    SET_PIN PIN=sound VALUE={beep_state}
 
 [gcode_macro CANCEL_PRINT]
 rename_existing: BASE_CANCEL_PRINT

--- a/configs/x-smart-3/control.cfg
+++ b/configs/x-smart-3/control.cfg
@@ -15,7 +15,7 @@ gcode:
     {% set z_end = printer.toolhead.axis_maximum.z - 1 %}
     G90
     G0 Z{z_end} F5000
-    G0 X5 Y180 F10000
+    G0 X5 Y180 F5000
 
     # clear pause state in case of cancel after pause
     CLEAR_PAUSE

--- a/configs/x-smart-3/control.cfg
+++ b/configs/x-smart-3/control.cfg
@@ -4,8 +4,15 @@ gcode:
 [gcode_macro PRINT_END]
 Description: After print clean up
 gcode:
+    # retract
+    {% set extruder_temp = printer.extruder.temperature %}
+    {% set extruder_min_temp = printer.configfile.settings.extruder.min_extrude_temp %}
+    {% if extruder_temp > extruder_min_temp %}
+        G91
+        G0 E-0.5
+    {% endif %}
     # lower bed & park toolhead
-    {% set z_end = printer.configfile.settings.stepper_z.position_max - 1 %}
+    {% set z_end = printer.toolhead.axis_maximum.z - 1 %}
     G90
     G0 Z{z_end} F5000
     G0 X5 Y180 F10000

--- a/configs/x-smart-3/control.cfg
+++ b/configs/x-smart-3/control.cfg
@@ -4,6 +4,11 @@ gcode:
 [gcode_macro PRINT_END]
 Description: After print clean up
 gcode:
+    # lower bed & park toolhead
+    G90
+    G0 Z175
+    G0 X5 Y170 F12000
+
     # clear pause state in case of cancel after pause
     CLEAR_PAUSE
     # set timeout back to configured value
@@ -32,7 +37,7 @@ gcode:
     SET_FILAMENT_SENSOR SENSOR=fila ENABLE=0
 
     # annoy user into removing print
-    {% set beep_state = printer["output_pin sound"].value|int %}
+    {% set beep_state = printer["output_pin sound"].value | int %}
         BEEP_ON
         BEEP I=2 DUR=1000
     {% printer["output_pin sound"].value = beep_state %}

--- a/configs/x-smart-3/control.cfg
+++ b/configs/x-smart-3/control.cfg
@@ -2,29 +2,40 @@
 gcode:
 
 [gcode_macro PRINT_END]
+Description: After print clean up
 gcode:
-    ; set timeout back to configured value
-    SET_IDLE_TIMEOUT TIMEOUT={printer.configfile.settings.idle_timeout.timeout}
+    # clear pause state in case of cancel after pause
     CLEAR_PAUSE
-#   SDCARD_RESET_FILE
+    # set timeout back to configured value
+    SET_IDLE_TIMEOUT TIMEOUT={printer.configfile.settings.idle_timeout.timeout}
 
-    M106 P2 S0
-    M106 P0 S0
-    M106 P3 S0   #开启活性炭风扇/Turn on the activated carbon fan
-
+    # stop fans
+    M107
+    # exdruder heater off
     M104 S0
+    # bed heater off
     M140 S0
-#   M141 S0
+    # chamber heater off
+    M141 S0
 
+    # reset speed override
     M220 S100
+    # reset extruder flow override
     M221 S100
+    # stop motors
     M84
-    SET_FILAMENT_SENSOR SENSOR=fila ENABLE=0
-    #恢复调平数据/Restore leveling data
-    BED_MESH_CLEAR
-    BED_MESH_PROFILE LOAD=default
+
+    # reset bed mesh to `kamp` profile
     G31
-    BEEP I=2 DUR=500
+
+    # disable filament sensor
+    SET_FILAMENT_SENSOR SENSOR=fila ENABLE=0
+
+    # annoy user into removing print
+    {% set beep_state = printer["output_pin sound"].value|int %}
+        BEEP_ON
+        BEEP I=2 DUR=1000
+    {% printer["output_pin sound"].value = beep_state %}
 
 [gcode_macro CANCEL_PRINT]
 rename_existing: BASE_CANCEL_PRINT

--- a/configs/x-smart-3/macros.cfg
+++ b/configs/x-smart-3/macros.cfg
@@ -98,14 +98,13 @@ gcode:
 ##
 
 [gcode_macro M141]
-# Set chamber heater temperature (no wait)
+Description: Set chamber heater temperature
 # Parameters
 #   Snnn Active/Target temperature
 gcode:
-    {% if params.S is defined %}
-        SET_HEATER_TEMPERATURE HEATER=chamber TARGET={params.S}
-    {% else %}
-        SET_HEATER_TEMPERATURE HEATER=chamber TARGET=0
+    {% set temp = params.S | default(0) %}
+    {% if printer['heater chamber'] is defined %}
+        SET_HEATER_TEMPERATURE HEATER=chamber TARGET={temp}
     {% endif %}
 
 [gcode_macro M106]
@@ -139,12 +138,14 @@ gcode:
 rename_existing:M107.1
 gcode:
     M107.1
-    {% if printer['fan_generic exhaust_fan'] is defined %}
-        SET_FAN_SPEED FAN=exhaust_fan SPEED=0
-    {% endif %}
-    {% if printer['fan_generic aux_part_fan'] is defined %}
-        SET_FAN_SPEED FAN=aux_part_fan SPEED=0
-    {% endif %}
+    # Edit fan names here, as needed
+    {% set fans = ["aux_part_fan", "exhaust_fan"] %}
+
+    {% for fan in fans %}
+        {% if printer['fan_generic {{ fan }}'] is defined %}
+            SET_FAN_SPEED FAN={{ fan }} SPEED=0
+        {% endif %}
+    {% endfor %}
 
 ## ===========================================================================
 # M macros 200-299


### PR DESCRIPTION
Rewrite PRINT_END to use correct gcodes.

Modify M141 to not error if chamber heater is not installed. 

Modify M107 to make changing fan names easier.

Add beeping and retraction.