### PR TITLE
Switch to temp fan for pi

### DIFF
--- a/configs/x-smart-3/fans.cfg
+++ b/configs/x-smart-3/fans.cfg
@@ -11,10 +11,14 @@ hardware_pwm: false
 
 # Stepper/mainboard fan
 # Location: side of mainboard near stepper drivers
-[controller_fan controller_fan]
+[temperature_fan controller_fan]
 pin: PA8
+sensor_type: temperature_host
 shutdown_speed: 1.0
-kick_start_time: 0.5
+min_temp: 30.0
+max_temp: 80.0
+control: watermark
+target_temp: 60.0
 
 # Heatbreak fan
 # Location: right side of heatbreak

--- a/configs/x-smart-3/temps.cfg
+++ b/configs/x-smart-3/temps.cfg
@@ -16,10 +16,10 @@ sensor_pin: PA0
 max_power: 1.0
 min_temp: -20
 max_temp: 125
-control = pid
-pid_Kp=62.293
-pid_Ki=0.931
-pid_Kd=1041.858
+control: pid
+pid_Kp: 62.293
+pid_Ki: 0.931
+pid_Kd: 1041.858
 
 [verify_heater extruder]
 max_error: 120


### PR DESCRIPTION
The Pi tends to run hot when the fan is off, especially when ambient temperature is elevated.

This PR converts the board fan from a `controller_fan` to a `temperature_fan` with a target temp of 60C.

Also fix some formatting.